### PR TITLE
Add Liquid regex replace filters

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -190,7 +190,15 @@ module LiquidInterpolatable
         'concat(' << subs.join(', ') << ')'
       end
     end
-
+    
+    def regex_replace(input, regex, replacement = ''.freeze)
+      input.to_s.gsub(Regexp.new(regex), replacement.to_s)
+    end
+    
+    def regex_replace_first(input, regex, replacement = ''.freeze)
+      input.to_s.sub(Regexp.new(regex), replacement.to_s)
+    end
+    
     private
 
     def logger


### PR DESCRIPTION
Copied and tweaked the general idea from [here](https://github.com/Shopify/liquid/issues/202#issuecomment-19112872). Essentially using the same code that [Liquid uses](https://github.com/Shopify/liquid/blob/master/lib/liquid/standardfilters.rb#L185) for their `replace` filter.

This should resolve #859 and #885